### PR TITLE
Exclude the properties from the object on the other side of the equation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ use(chaiExclude);
 1. Excluding a property from an object
 
 ```js
-expect({ a: 'a', b: 'b' }).excluding('a').to.deep.equal({ b: 'b' })
+expect({ a: 'a', b: 'b' }).excluding('a').to.deep.equal({ a: 'z', b: 'b' })
 ```
 
 2. Excluding multiple top level properties from an object

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -28,8 +28,12 @@ module.exports = (chai, utils) => {
   }
 
   /**
-   * Override of the standard assertEqual to also remove the keys from the other part of the equation.
-  */
+   * Override of the standard assertEqual to also remove the keys from the
+   * other part of the equation.
+   * 
+   * @param {Object} _super
+   * @returns {Function}
+   */
   function assertEqual (_super) {
     return function (val) {
       if (utils.type(val).toLowerCase() === 'object') {
@@ -83,7 +87,7 @@ module.exports = (chai, utils) => {
     return this
   })
 
+  Assertion.overwriteMethod('eq', assertEqual)
   Assertion.overwriteMethod('equal', assertEqual)
   Assertion.overwriteMethod('equals', assertEqual)
-  Assertion.overwriteMethod('eq', assertEqual)
 }

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -8,7 +8,7 @@ module.exports = (chai, utils) => {
    * @param  {Array}  props  Array of keys to remove
    * @return {Object}
    */
-  function removeKeys(obj, props, recursive = false) {
+  function removeKeys (obj, props, recursive = false) {
     const res = {}
     const keys = Object.keys(obj)
     const isRecursive = !!recursive
@@ -30,16 +30,16 @@ module.exports = (chai, utils) => {
   /**
    * Override of the standard assertEqual to also remove the keys from the other part of the equation.
   */
-  function assertEqual(_super) {
+  function assertEqual (_super) {
     return function (val) {
       if (utils.type(val).toLowerCase() === 'object') {
         if (utils.flag(this, 'excluding')) {
-          val = removeKeys(val, utils.flag(this, 'excludingProps'));
+          val = removeKeys(val, utils.flag(this, 'excludingProps'))
         } else if (utils.flag(this, 'excludingEvery')) {
-          val = removeKeys(val, utils.flag(this, 'excludingProps'), true);
+          val = removeKeys(val, utils.flag(this, 'excludingProps'), true)
         }
       }
-      _super.apply(this, arguments);
+      _super.apply(this, arguments)
     }
   }
 
@@ -57,8 +57,8 @@ module.exports = (chai, utils) => {
 
     this._obj = removeKeys(this._obj, props)
 
-    utils.flag(this, 'excluding', true);
-    utils.flag(this, 'excludingProps', props);
+    utils.flag(this, 'excluding', true)
+    utils.flag(this, 'excludingProps', props)
 
     return this
   })
@@ -77,13 +77,13 @@ module.exports = (chai, utils) => {
 
     this._obj = removeKeys(this._obj, props, true)
 
-    utils.flag(this, 'excludingEvery', true);
-    utils.flag(this, 'excludingProps', props);
+    utils.flag(this, 'excludingEvery', true)
+    utils.flag(this, 'excludingProps', props)
 
     return this
   })
 
-  Assertion.overwriteMethod('equal', assertEqual);
-  Assertion.overwriteMethod('equals', assertEqual);
-  Assertion.overwriteMethod('eq', assertEqual);
+  Assertion.overwriteMethod('equal', assertEqual)
+  Assertion.overwriteMethod('equals', assertEqual)
+  Assertion.overwriteMethod('eq', assertEqual)
 }

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -8,7 +8,7 @@ module.exports = (chai, utils) => {
    * @param  {Array}  props  Array of keys to remove
    * @return {Object}
    */
-  function removeKeys (obj, props, recursive = false) {
+  function removeKeys(obj, props, recursive = false) {
     const res = {}
     const keys = Object.keys(obj)
     const isRecursive = !!recursive
@@ -27,6 +27,22 @@ module.exports = (chai, utils) => {
     return res
   }
 
+  /**
+   * Override of the standard assertEqual to also remove the keys from the other part of the equation.
+  */
+  function assertEqual(_super) {
+    return function (val) {
+      if (utils.type(val).toLowerCase() === 'object') {
+        if (utils.flag(this, 'excluding')) {
+          val = removeKeys(val, utils.flag(this, 'excludingProps'));
+        } else if (utils.flag(this, 'excludingEvery')) {
+          val = removeKeys(val, utils.flag(this, 'excludingProps'), true);
+        }
+      }
+      _super.apply(this, arguments);
+    }
+  }
+
   Assertion.addMethod('excluding', function (props) {
     utils.expectTypes(this, ['object'])
 
@@ -40,6 +56,9 @@ module.exports = (chai, utils) => {
     }
 
     this._obj = removeKeys(this._obj, props)
+
+    utils.flag(this, 'excluding', true);
+    utils.flag(this, 'excludingProps', props);
 
     return this
   })
@@ -58,6 +77,13 @@ module.exports = (chai, utils) => {
 
     this._obj = removeKeys(this._obj, props, true)
 
+    utils.flag(this, 'excludingEvery', true);
+    utils.flag(this, 'excludingProps', props);
+
     return this
   })
+
+  Assertion.overwriteMethod('equal', assertEqual);
+  Assertion.overwriteMethod('equals', assertEqual);
+  Assertion.overwriteMethod('eq', assertEqual);
 }

--- a/test/chai-exclude.js
+++ b/test/chai-exclude.js
@@ -5,8 +5,17 @@ describe('chaiExclude', () => {
     expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ b: 'b', c: 'c' })
   })
 
+  it('should also exclude a key from the other object', () => {
+    expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ a: 'z', b: 'b', c: 'c' })
+  })
+
   it('should exclude an array of keys from the object', () => {
     expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ b: 'b' })
+  })
+
+  it('should also exclude an array of keys from the other object', () => {
+    expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b' })
+    expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b', c: 'c' })
   })
 
   it('should exclude nothing from the object if no keys are provided', () => {
@@ -61,6 +70,7 @@ describe('chaiExcludeEvery', () => {
       c: {
         b: {
           d: {
+            a: 'z',
             b: 'b',
             d: null
           }

--- a/test/chai-exclude.js
+++ b/test/chai-exclude.js
@@ -1,108 +1,60 @@
 const expect = require('chai').expect
 
-describe('chaiExclude', () => {
-  it('should exclude a key from the object', () => {
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ b: 'b', c: 'c' })
-  })
+describe('chai-exclude', () => { // eslint-disable-line
 
-  it('should also exclude a key from the other object', () => {
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ a: 'z', b: 'b', c: 'c' })
-  })
+  describe('excluding', () => {
+    it('should exclude a key from the object', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ b: 'b', c: 'c' })
+    })
 
-  it('should exclude an array of keys from the object', () => {
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ b: 'b' })
-  })
+    it('should also exclude a key from the other object', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ a: 'z', b: 'b', c: 'c' })
+    })
 
-  it('should also exclude an array of keys from the other object', () => {
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b' })
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b', c: 'c' })
-  })
+    it('should exclude an array of keys from the object', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ b: 'b' })
+    })
 
-  it('should exclude nothing from the object if no keys are provided', () => {
-    expect({ a: 'a', b: 'b', c: 'c' }).excluding().to.deep.equal({ a: 'a', b: 'b', c: 'c' })
-  })
+    it('should also exclude an array of keys from the other object', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b' })
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding(['a', 'c']).to.deep.equal({ a: 'z', b: 'b', c: 'c' })
+    })
 
-  it('should exclude top level key even if it is an object', () => {
-    const obj = {
-      a: 'a',
-      b: 'b',
-      c: {
+    it('should exclude nothing from the object if no keys are provided', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding().to.deep.equal({ a: 'a', b: 'b', c: 'c' })
+    })
+
+    it('should exclude nothing from the object if no matching keys are provided', () => {
+      expect({ a: 'a', b: 'b' }).excluding('x').to.deep.equal({ a: 'a', b: 'b' })
+      expect({ a: 'a', b: 'b' }).excluding(['x', 'y']).to.deep.equal({ a: 'a', b: 'b' })
+    })
+
+    it('should exclude top level key even if it is an object', () => {
+      const obj = {
         a: 'a',
-        b: {
-          a: 'a'
-        }
-      },
-      d: ['a', 'c']
-    }
-
-    const expectedObj = {
-      a: 'a',
-      b: 'b',
-      d: ['a', 'c']
-    }
-
-    expect(obj).excluding('c').to.deep.equal(expectedObj)
-  })
-})
-
-describe('chaiExcludeEvery', () => {
-  // Initial object that we will remove properties from across all tests
-  const initialObj = {
-    a: 'a',
-    b: 'b',
-    c: {
-      a: 'a',
-      b: {
-        a: 'a',
-        d: {
+        b: 'b',
+        c: {
           a: 'a',
-          b: 'b',
-          d: null
-        }
+          b: {
+            a: 'a'
+          }
+        },
+        d: ['a', 'c']
       }
-    },
-    d: ['a', 'c']
-  }
 
-  it('should exclude a key from multiple levels of a given object', () => {
-    const expectedObj = {
-      b: 'b',
-      c: {
-        b: {
-          d: {
-            a: 'z',
-            b: 'b',
-            d: null
-          }
-        }
-      },
-      d: ['a', 'c']
-    }
-
-    expect(initialObj).excludingEvery('a').to.deep.equal(expectedObj)
-  })
-
-  it('should exclude a key from multiple levels of a given object when value is not an object', () => {
-    const expectedObj = {
-      a: 'a',
-      c: {
+      const expectedObj = {
         a: 'a',
-        b: {
-          a: 'a',
-          d: {
-            a: 'a',
-            d: null
-          }
-        }
-      },
-      d: ['a', 'c']
-    }
+        b: 'b',
+        d: ['a', 'c']
+      }
 
-    expect(initialObj).excludingEvery('b').to.deep.equal(expectedObj)
+      expect(obj).excluding('c').to.deep.equal(expectedObj)
+    })
   })
 
-  it('should exclude no keys from a given object when only value for key is an object', () => {
-    const expectedObj = {
+  describe('excludingEvery', () => {
+    // Initial object that we will remove properties from across all tests
+    const initialObj = {
       a: 'a',
       b: 'b',
       c: {
@@ -119,42 +71,104 @@ describe('chaiExcludeEvery', () => {
       d: ['a', 'c']
     }
 
-    expect(initialObj).excludingEvery('c').to.deep.equal(expectedObj)
-  })
+    it('should exclude a key from multiple levels of a given object', () => {
+      const expectedObj = {
+        b: 'b',
+        c: {
+          b: {
+            d: {
+              a: 'z',
+              b: 'b',
+              d: null
+            }
+          }
+        },
+        d: ['a', 'c']
+      }
 
-  it('should exclude a key from multiple levels of a given object when value is an array or null', () => {
-    const expectedObj = {
-      a: 'a',
-      b: 'b',
-      c: {
+      expect(initialObj).excludingEvery('a').to.deep.equal(expectedObj)
+    })
+
+    it('should exclude a key from multiple levels of a given object when value is not an object', () => {
+      const expectedObj = {
         a: 'a',
-        b: {
+        c: {
           a: 'a',
-          d: {
+          b: {
             a: 'a',
-            b: 'b'
+            d: {
+              a: 'a',
+              d: null
+            }
+          }
+        },
+        d: ['a', 'c']
+      }
+
+      expect(initialObj).excludingEvery('b').to.deep.equal(expectedObj)
+    })
+
+    it('should exclude no keys from a given object when only value for key is an object', () => {
+      const expectedObj = {
+        a: 'a',
+        b: 'b',
+        c: {
+          a: 'a',
+          b: {
+            a: 'a',
+            d: {
+              a: 'a',
+              b: 'b',
+              d: null
+            }
+          }
+        },
+        d: ['a', 'c']
+      }
+
+      expect(initialObj).excludingEvery('c').to.deep.equal(expectedObj)
+    })
+
+    it('should exclude a key from multiple levels of a given object when value is an array or null', () => {
+      const expectedObj = {
+        a: 'a',
+        b: 'b',
+        c: {
+          a: 'a',
+          b: {
+            a: 'a',
+            d: {
+              a: 'a',
+              b: 'b'
+            }
           }
         }
       }
-    }
 
-    expect(initialObj).excludingEvery('d').to.deep.equal(expectedObj)
-  })
+      expect(initialObj).excludingEvery('d').to.deep.equal(expectedObj)
+    })
 
-  it('should exclude an array of keys from multiple levels of a given object', () => {
-    const expectedObj = {
-      c: {
-        b: {
-          d: {
+    it('should exclude an array of keys from multiple levels of a given object', () => {
+      const expectedObj = {
+        c: {
+          b: {
+            d: {
+            }
           }
         }
       }
-    }
 
-    expect(initialObj).excludingEvery(['a', 'b', 'c', 'd']).to.deep.equal(expectedObj)
+      expect(initialObj).excludingEvery(['a', 'b', 'c', 'd']).to.deep.equal(expectedObj)
+    })
+
+    it('should exclude nothing from the object if no keys are provided', () => {
+      expect(initialObj).excludingEvery().to.deep.equal(initialObj)
+    })
+
+    it('should exclude nothing from the object if no matching keys are provided', () => {
+      expect(initialObj).excludingEvery('x').to.deep.equal(initialObj)
+      expect(initialObj).excludingEvery(['x', 'y']).to.deep.equal(initialObj)
+    })
   })
 
-  it('should exclude nothing from the object if no keys are provided', () => {
-    expect(initialObj).excludingEvery().to.deep.equal(initialObj)
-  })
-})
+})  // eslint-disable-line


### PR DESCRIPTION
Hi,
in the example of https://github.com/chaijs/chai/issues/885 there is a uniqueId on both sides of the equation. So only excluding the properties on one side of the equation doesn't fully solve the problem. So here my attempt at updating the code to also cater for this situation.
Best regards