### PR TITLE
make chai-exclude compatible with array of objects and chai-things

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Sometimes you'll need to exclude object properties that generate unique values w
 
 https://github.com/chaijs/chai/issues/885
 
+Works with both array of objects and objects.
+
 ## Installation
 
 ```bash
@@ -62,8 +64,13 @@ use(chaiExclude);
 1. Excluding a top level property from an object
 
 ```js
+// Object
 expect({ a: 'a', b: 'b' }).excluding('a').to.deep.equal({ b: 'b' })
 expect({ a: 'a', b: 'b' }).excluding('a').to.deep.equal({ a: 'z', b: 'b' })
+
+// Array
+expect([{ a: 'a', b: 'b' }]).excluding('a').to.deep.equal([{ b: 'b' }])
+expect([{ a: 'a', b: 'b' }]).excluding('a').to.deep.equal([{ a: 'z', b: 'b' }])
 ```
 
 2. Excluding multiple top level properties from an object
@@ -78,8 +85,24 @@ const obj = {
   }
 }
 
+// Object
 expect(obj).excluding(['a', 'c']).to.deep.equal({ b: 'b' })
 expect(obj).excluding(['a', 'c']).to.deep.equal({ a:'z', b: 'b' })
+
+const array = [
+  {
+    a: 'a',
+    b: 'b',
+    c: {
+      d: 'd',
+      e: 'e'
+    }
+  }
+]
+
+// Array
+expect(array).excluding(['a', 'c']).to.deep.equal([{ b: 'b' }])
+expect(array).excluding(['a', 'c']).to.deep.equal([{ a: 'z', b: 'b' }])
 ```
 
 ### b) excludingEvery
@@ -87,7 +110,7 @@ expect(obj).excluding(['a', 'c']).to.deep.equal({ a:'z', b: 'b' })
 1. Excluding every property in a deeply nested object
 
 ```js
-const actual = {
+const actualObj = {
   a: 'a',
   b: 'b',
   c: {
@@ -104,7 +127,9 @@ const actual = {
   d: ['a', 'c']
 }
 
-const expected = {
+const actualArray = [actualObj]
+
+const expectedObj = {
   a: 'z',     // a is excluded from comparison
   b: 'b',
   c: {
@@ -118,13 +143,19 @@ const expected = {
   d: ['a', 'c']
 }
 
-expect(actual).excludingEvery('a').to.deep.equal(expected)
+const expectedObj = [expectedObj]
+
+// Object
+expect(actualObj).excludingEvery('a').to.deep.equal(expectedObj)
+
+// Array
+expect(actualArray).excludingEvery('a').to.deep.equal(expectedArray)
 ```
 
 2. Excluding multiple properties in a deeply nested object
 
 ```js
-const actual = {
+const actualObj = {
   a: 'a',
   b: 'b',
   c: {
@@ -141,14 +172,23 @@ const actual = {
   d: ['a', 'c']
 }
 
-const expected = {
+const actualArray = [actualObj]
+
+const expectedObj = {
   b: 'b',
   c: {
     b: {
     }
   }
+}
 
-expect(actual).excludingEvery(['a', 'd']).to.deep.equal(expected)
+const expectedArray = [expectedObj]
+
+// Object
+expect(actualObj).excludingEvery(['a', 'd']).to.deep.equal(expectedObj)
+
+// Array
+expect(actualArray).excludingEvery(['a', 'd']).to.deep.equal(expectedArray)
 ```
 
 ## Contributing

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -2,19 +2,21 @@ module.exports = (chai, utils) => {
   const Assertion = chai.Assertion
 
   /**
-   * Remove keys from an object or an array and return a new object.
+   * Remove keys from an object or an array.
    *
    * @param   {Object|Array}  val       object or array to remove keys
-   * @param   {Array}   props     array of keys to remove
-   * @param   {Boolean} recursive true if property needs to be removed recursively
+   * @param   {Array}         props     array of keys to remove
+   * @param   {Boolean}       recursive true if property needs to be removed recursively
    * @returns {Object}
    */
   function removeKeysFrom (val, props, recursive = false) {
     if (isObject(val)) {
       return removeKeysFromObject(val, props, recursive)
     }
+
     return removeKeysFromArray(val, props, recursive)
   }
+
   /**
    * Remove keys from an object and return a new object.
    *
@@ -64,9 +66,9 @@ module.exports = (chai, utils) => {
 
     for (let i = 0; i < array.length; i++) {
       if (isObject(array[i])) {
-        val = removeKeysFromObject(array[i], props, true)
+        val = removeKeysFromObject(array[i], props, recursive)
       } else if (isArray(array[i])) {
-        val = removeKeysFromArray(array[i], props, true)
+        val = removeKeysFromArray(array[i], props, recursive)
       } else {
         val = array[i]
       }
@@ -105,12 +107,10 @@ module.exports = (chai, utils) => {
    */
   function assertEqual (_super) {
     return function (val) {
-      if (utils.type(val).toLowerCase() === 'object') {
-        if (utils.flag(this, 'excluding')) {
-          val = removeKeysFromObject(val, utils.flag(this, 'excludingProps'))
-        } else if (utils.flag(this, 'excludingEvery')) {
-          val = removeKeysFromObject(val, utils.flag(this, 'excludingProps'), true)
-        }
+      if (utils.flag(this, 'excluding')) {
+        val = removeKeysFrom(val, utils.flag(this, 'excludingProps'))
+      } else if (utils.flag(this, 'excludingEvery')) {
+        val = removeKeysFrom(val, utils.flag(this, 'excludingProps'), true)
       }
 
       _super.apply(this, arguments)

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -2,6 +2,20 @@ module.exports = (chai, utils) => {
   const Assertion = chai.Assertion
 
   /**
+   * Remove keys from an object or an array and return a new object.
+   *
+   * @param   {Object|Array}  val       object or array to remove keys
+   * @param   {Array}   props     array of keys to remove
+   * @param   {Boolean} recursive true if property needs to be removed recursively
+   * @returns {Object}
+   */
+  function removeKeysFrom (val, props, recursive = false) {
+    if (isObject(val)) {
+      return removeKeysFromObject(val, props, recursive)
+    }
+    return removeKeysFromArray(val, props, recursive)
+  }
+  /**
    * Remove keys from an object and return a new object.
    *
    * @param   {Object}  obj       object to remove keys
@@ -107,7 +121,7 @@ module.exports = (chai, utils) => {
    * Add a new method 'excluding' to the assertion library.
    */
   Assertion.addMethod('excluding', function (props) {
-    utils.expectTypes(this, ['object'])
+    utils.expectTypes(this, ['object', 'array'])
 
     const obj = this._obj
 
@@ -120,7 +134,7 @@ module.exports = (chai, utils) => {
       props = [props]
     }
 
-    this._obj = removeKeysFromObject(obj, props)
+    this._obj = removeKeysFrom(obj, props)
 
     utils.flag(this, 'excluding', true)
     utils.flag(this, 'excludingProps', props)
@@ -132,7 +146,7 @@ module.exports = (chai, utils) => {
    * Add a new method 'excludingEvery' to the assertion library.
    */
   Assertion.addMethod('excludingEvery', function (props) {
-    utils.expectTypes(this, ['object'])
+    utils.expectTypes(this, ['object', 'array'])
 
     const obj = this._obj
 
@@ -145,7 +159,7 @@ module.exports = (chai, utils) => {
       props = [props]
     }
 
-    this._obj = removeKeysFromObject(obj, props, true)
+    this._obj = removeKeysFrom(obj, props, true)
 
     utils.flag(this, 'excludingEvery', true)
     utils.flag(this, 'excludingProps', props)

--- a/test/chai-exclude.js
+++ b/test/chai-exclude.js
@@ -216,6 +216,59 @@ describe('chai-exclude', () => { // eslint-disable-line
       expect(obj).excludingEvery('a').to.deep.equal(expectedObj)
     })
 
+    it('should exclude keys from objects inside of array at the root', () => {
+      const obj = [
+        {
+          a: 'a',
+          b: {
+            a: 'a',
+            d: {
+              a: 'a',
+              b: 'b',
+              d: null
+            }
+          }
+        },
+        null,
+        1,
+        'string',
+        [
+          {
+            a: 'a',
+            b: {
+              a: 'a',
+              c: null,
+              d: 'd'
+            }
+          }
+        ]
+      ]
+
+      const expectedObj = [
+        {
+          b: {
+            d: {
+              b: 'b',
+              d: null
+            }
+          }
+        },
+        null,
+        1,
+        'string',
+        [
+          {
+            b: {
+              c: null,
+              d: 'd'
+            }
+          }
+        ]
+      ]
+
+      expect(obj).excludingEvery('a').to.deep.equal(expectedObj)
+    })
+
     it('should exclude nothing from the object if no keys are provided', () => {
       expect(initialObj).excludingEvery().to.deep.equal(initialObj)
     })

--- a/test/chai-exclude.js
+++ b/test/chai-exclude.js
@@ -50,7 +50,40 @@ describe('chai-exclude', () => { // eslint-disable-line
 
       expect(obj).excluding('c').to.deep.equal(expectedObj)
     })
-  })
+
+    it('should exclude top level key(s) from array of objects', () => {
+      expect([{ a: 'a', b: 'b', c: 'c' }]).excluding('a').to.deep.equal([{ b: 'b', c: 'c' }])
+      expect([{ a: 'a', b: 'b', c: 'c' }]).excluding(['a', 'b']).to.deep.equal([{ c: 'c' }])
+    })
+
+    it('should exclude top level key from array of objects even if the key is an object', () => {
+      const initialArray = [
+        {
+          a: 'a',
+          b: 'b',
+          c: {
+            a: 'a',
+            b: {
+              a: 'a'
+            }
+          },
+          d: ['a', 'c']
+        }
+      ]
+
+      const expectedArray = [
+        {
+          a: 'a',
+          b: 'b',
+          c: 'z',
+          d: ['a', 'c']
+        }
+      ]
+
+      expect(initialArray).excluding('c').to.deep.equal(expectedArray)
+    })
+
+}) // eslint-disable-line
 
   describe('excludingEvery', () => {
     // Initial object that we will remove properties from
@@ -216,8 +249,37 @@ describe('chai-exclude', () => { // eslint-disable-line
       expect(obj).excludingEvery('a').to.deep.equal(expectedObj)
     })
 
-    it('should exclude keys from objects inside of array at the root', () => {
-      const obj = [
+    it('should exclude keys from simple array of objects at the root', () => {
+      const initialArray = [
+        {
+          a: 'a',
+          b: {
+            a: 'a',
+            d: {
+              a: 'a',
+              b: 'b',
+              d: null
+            }
+          }
+        }
+      ]
+
+      const expectedArray = [
+        {
+          b: {
+            d: {
+              b: 'b',
+              d: null
+            }
+          }
+        }
+      ]
+
+      expect(initialArray).excludingEvery('a').to.deep.equal(expectedArray)
+    })
+
+    it('should exclude key(s) from objects inside of array at the root', () => {
+      const initialArray = [
         {
           a: 'a',
           b: {
@@ -244,7 +306,7 @@ describe('chai-exclude', () => { // eslint-disable-line
         ]
       ]
 
-      const expectedObj = [
+      const expectedArray1 = [
         {
           b: {
             d: {
@@ -266,7 +328,25 @@ describe('chai-exclude', () => { // eslint-disable-line
         ]
       ]
 
-      expect(obj).excludingEvery('a').to.deep.equal(expectedObj)
+      const expectedArray2 = [
+        {
+          b: {
+          }
+        },
+        null,
+        1,
+        'string',
+        [
+          {
+            b: {
+              c: null
+            }
+          }
+        ]
+      ]
+
+      expect(initialArray).excludingEvery('a').to.deep.equal(expectedArray1)
+      expect(initialArray).excludingEvery(['a', 'd']).to.deep.equal(expectedArray2)
     })
 
     it('should exclude nothing from the object if no keys are provided', () => {


### PR DESCRIPTION
I’m creating the PR from github so this is a work in progress but this already make it possible to do this:

`except(arrayOfObj).to.include.something.that.excludingEvery("a").deep.equals(obj)`