### PR TITLE
Update chai-exclude.d.ts to use keyof.

### DIFF
--- a/lib/chai-exclude.d.ts
+++ b/lib/chai-exclude.d.ts
@@ -22,7 +22,7 @@ declare namespace Chai {
      * @param props     Properties or keys to exclude.
      * @param message   Message to display on error.
      */
-    deepEqualExcluding<T>(actual: T, expected: T, props: string | string[], message?: string): void;
+    deepEqualExcluding<T>(actual: T, expected: T, props: keyof T | keyof T[], message?: string): void;
 
     /**
      * Asserts that actual is deeply equal to expected excluding properties any level deep.
@@ -33,6 +33,6 @@ declare namespace Chai {
      * @param props     Properties or keys to exclude.
      * @param message   Message to display on error.
      */
-    deepEqualExcludingEvery<T>(actual: T, expected: T, props: string | string[], message?: string): void;
+    deepEqualExcludingEvery<T>(actual: T, expected: T, props: keyof T | keyof T[], message?: string): void;
   }
 }


### PR DESCRIPTION
Prevents typos on property names by using the `keyof` keyword introduced in TypeScript 2.1

For example:

```typescript
interface Data {
  field1: number;
  field2: number;
}

const expected: Data = { field1: 1, field2: 2 };
const actual: Data = { field1: 3, field2: 4 };

assert.deepEqualExcluding(actual, expected, "field1"); // OK
assert.deepEqualExcluding(actual, expected, "field3"); // Compiler error
```

Would love to enable it for `expect`/`should` styles too, unfortunately, the `Assertion` interface in `<reference types="chai" />` is not generic.

Modifying `Chai.Assertion` in [DefinitelyTyped/chai](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/chai) to make it generic may break lots of builds out there using the `Assertion` type directly with `"Generic type 'Assertion<T>' requires 1 type argument(s)."` errors.