### PR TITLE
Use non-arrow-function for export

### DIFF
--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -121,6 +121,7 @@ module.exports = function (chai, utils) {
         val = removeKeysFrom(val, props, true)
       }
 
+      arguments[0] = val;
       _super.apply(this, arguments)
     }
   }

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -121,7 +121,9 @@ module.exports = function (chai, utils) {
         val = removeKeysFrom(val, props, true)
       }
 
+      // In case of 'use strict' and babelified code
       arguments[0] = val;
+      
       _super.apply(this, arguments)
     }
   }

--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -1,6 +1,6 @@
 const fclone = require('fclone')
 
-module.exports = (chai, utils) => {
+module.exports = function (chai, utils) {
   const assert = chai.assert
   const Assertion = chai.Assertion
 


### PR DESCRIPTION
Hello,
This is a tiny fix to allow the lib to run in IE11 (did it via karma).

I also found a similar problem when attempting to babelify the code as babel adds a `"use strict"` to the module, which breaks `assertEqual` because `arguments` [behaves slightly differently in strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Making_eval_and_arguments_simpler). It's also an easy fix, should I do that while I'm at it?