### PR TITLE
Change export to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ use(chaiExclude);
 
 ```js
 import { use } from 'chai';
-import chaiExclude = require('chai-exclude');
+import chaiExclude from 'chai-exclude';
 
 use(chaiExclude);
 

--- a/lib/chai-exclude.d.ts
+++ b/lib/chai-exclude.d.ts
@@ -3,7 +3,7 @@
 declare module "chai-exclude" {
   function chaiExclude(chai: any, utils: any): void;
 
-  export = chaiExclude;
+  export default chaiExclude;
 }
 
 declare namespace Chai {


### PR DESCRIPTION
```ts
import chaiExclude = require('chai-exclude')
```
is non-standard behavior, and only exists for backwards compatibility in the typescript [see typescript spec](https://github.com/Microsoft/TypeScript/blob/4b96edf72faf6f9b6b464e148c9c02eac96aa4bd/doc/spec.md#1133-import-require-declarations), in addition, using webpack alongside typescript makes this type of import impossible. The workaround is to add the flag `--allowSyntheticDefaultImports` to your typescript config, which means less less specificity in your project.

the ecmascript import that both webpack and typescript can understand looks like this:
```ts
import chaiExclude from 'chai-exclude'
```


This typechange will allow that kind of import, however, this will mean developers using future versions of this library will need to update their imports to prevent typescript from throwing a type error