### PR TITLE
Add default export to js file for TypeScript

### DIFF
--- a/lib/chai-exclude.js
+++ b/lib/chai-exclude.js
@@ -1,6 +1,6 @@
 const fclone = require('fclone')
 
-module.exports = function (chai, utils) {
+function chaiExclude(chai, utils) {
   const assert = chai.assert
   const Assertion = chai.Assertion
 
@@ -200,3 +200,6 @@ module.exports = function (chai, utils) {
   Assertion.overwriteMethod('equal', assertEqual)
   Assertion.overwriteMethod('equals', assertEqual)
 }
+
+module.exports = chaiExclude
+module.exports.default = chaiExclude // for Typescript


### PR DESCRIPTION
follow up to pr #19, this adds a `module.export.default = chaiExclude` so typescript linters do not complain

Similar setup in the `chalk` package.
https://github.com/chalk/chalk/blob/master/index.d.ts#L276
https://github.com/chalk/chalk/blob/master/index.js#L213