### PR TITLE
Forward returned value from assertEqual

### DIFF
--- a/chai-exclude.js
+++ b/chai-exclude.js
@@ -124,7 +124,7 @@ function chaiExclude (chai, utils) {
       // In case of 'use strict' and babelified code
       arguments[0] = val
 
-      _super.apply(this, arguments)
+      return _super.apply(this, arguments)
     }
   }
 


### PR DESCRIPTION
We use chai-exclude and chai-as-promised in our project. With chai-as-promised, assertions return promises, for example:

```js
await expect(Promise.resolve(1)).to.eventually.equal(8);
```

But chai-exclude drops the promise because it doesn't forward the return value of the parent assertEqual(). This PR fixes it.