### PR TITLE
Added support to exclude nested keys

### DIFF
--- a/chai-exclude.test.js
+++ b/chai-exclude.test.js
@@ -19,6 +19,17 @@ describe('chai-exclude', () => {
   })
 
   /**
+   * Uses the same 'excluding' Assertion API underneath, thus the fewer amount of tests.
+   */
+   describe('assert.deepEqualExcludingNested', () => {
+    it('should exclude key(s) from comparison', () => {
+      assert.deepEqualExcludingNested({ a: { a1: 'a1', a2: 'a2' }, b: 'b', c: 'c' }, { a: { a2: 'a2' }, b: 'b', c: 'c' }, 'a.a1')
+      assert.deepEqualExcludingNested({ a: { a1: 'a1', a2: 'a2' }, b: 'b', c: 'c' }, { a: { a2: 'a2' }, c: 'c' }, ['a.a1', 'b'])
+      assert.deepEqualExcludingNested([{ a: { a1: 'a1', a2: 'a2' }, b: 'b', c: 'c' }], [{ a: { a2: 'a2' }, c: 'c' }], ['a.a1', 'b'])
+    })
+   })
+
+  /**
    * Uses the same 'excludingEvery' Assertion API underneath, thus the fewer amount of tests.
    */
   describe('assert.deepEqualExcludingEvery', () => {
@@ -630,6 +641,90 @@ describe('chai-exclude', () => {
     it('should exclude nothing from the object if no matching keys are provided and eql/eqls is used', () => {
       expect({ a: new Date(0) }).excludingEvery('b').to.be.eql({ a: new Date(0) })
       expect({ a: new Date(0) }).excludingEvery(['b', 'c']).to.be.eqls({ a: new Date(0) })
+    })
+  })
+
+  describe('expect.excludingNested', () => {
+    const initialObj = {
+      a: 'a',
+      b: {
+        b1: 'b1',
+        b2: {
+          b21: 'b21',
+          b22: 'b22',
+        },
+      },
+      c: [ 0, 1, { cX: 'cX' }],
+    }
+
+    it('should exclude nothing if no key is provided', () => {
+      expect(initialObj).excludingNested().to.deep.equal(initialObj)
+    })
+
+    it('should exclude single non-nested key when provided', () => {
+      expect(initialObj).excludingNested('a').to.deep.equal({
+        b: {
+          b1: 'b1',
+          b2: {
+            b21: 'b21',
+            b22: 'b22',
+          },
+        },
+        c: [ 0, 1, { cX: 'cX' }],
+      })
+    })
+
+    it('should exclude single nested key when provided', () => {
+      expect(initialObj).excludingNested('b.b1').to.deep.equal({
+        a: 'a',
+        b: {
+          b2: {
+            b21: 'b21',
+            b22: 'b22',
+          },
+        },
+        c: [ 0, 1, { cX: 'cX' }],
+      })
+    })
+
+    it('should exclude multiple nested keys when provided', () => {
+      expect(initialObj).excludingNested(['b.b1', 'b.b2.b22']).to.deep.equal({
+        a: 'a',
+        b: {
+          b2: {
+            b21: 'b21',
+          },
+        },
+        c: [ 0, 1, { cX: 'cX' }],
+      })
+    })
+
+    it('should exclude nested key from array', () => {
+      expect(initialObj).excludingNested('c.0').to.deep.equal({
+        a: 'a',
+        b: {
+          b1: 'b1',
+          b2: {
+            b21: 'b21',
+            b22: 'b22',
+          },
+        },
+        c: [ 1, { cX: 'cX' }],
+      })
+    })
+
+    it('should exclude multiple nested keys from array', () => {
+      expect(initialObj).excludingNested(['c.0', 'c.2.cX']).to.deep.equal({
+        a: 'a',
+        b: {
+          b1: 'b1',
+          b2: {
+            b21: 'b21',
+            b22: 'b22',
+          },
+        },
+        c: [ 1, { }],
+      })
     })
   })
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare namespace Chai {
   interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
     excluding(props: string | string[]): Assertion;
     excludingEvery(props: string | string[]): Assertion;
+    excludingNested(props: string | string[]): Assertion;
   }
 
   interface Assert {
@@ -30,5 +31,15 @@ declare namespace Chai {
      * @param message   Message to display on error.
      */
     deepEqualExcludingEvery<T>(actual: T | T[], expected: T | T[], props: keyof T | (keyof T)[], message?: string): void;
+
+    /**
+     * Asserts that actual is deeply equal to expected excluding nested properties.
+     *
+     * @param actual    Actual value.
+     * @param expected  Expected value.
+     * @param props     Properties or keys to exclude.
+     * @param message   Message to display on error.
+     */
+     deepEqualExcludingNested<T>(actual: T | T[], expected: T | T[], props: string | (string)[], message?: string): void;
   }
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ import * as chaiExclude from './chai-exclude'
 // @ts-ignore
 chai.use(chaiExclude)
 
-const object = { str: 'a', num: 1 }
+const object = { str: 'a', num: 1, obj: { str: 'x', num: 2 } }
 
 // BDD API (expect)
 expectType<Chai.Assertion>(chai.expect(object).excluding('str'))
@@ -15,9 +15,13 @@ expectType<Chai.Assertion>(chai.expect(object).excluding(['str', 'num']))
 expectType<Chai.Assertion>(chai.expect(object).excludingEvery('str'))
 expectType<Chai.Assertion>(chai.expect(object).excludingEvery(['str', 'num']))
 expectType<Chai.Assertion>(chai.expect(object).excludingEvery(['str', 'num']))
+expectType<Chai.Assertion>(chai.expect(object).excludingNested('obj.str'))
+expectType<Chai.Assertion>(chai.expect(object).excludingNested(['obj.str', 'obj.num']))
 
 chai.expect({ a: 1 }).excluding('a').to.deep.equal({ a: 1 })
+chai.expect(object).excluding('obj.str').to.deep.equal({ str: 'a', num: 1, obj: { num: 2 } })
 
 // Assert API
 chai.assert.deepEqualExcluding({ a: 'a', b: 'b' }, { b: 'b' }, 'a')
 chai.assert.deepEqualExcludingEvery({ a: 'a', b: 'b' }, { c: 'b' }, 'a')
+chai.assert.deepEqualExcludingNested({ a: 'a', b: 'b' }, { c: 'b' }, 'obj.str')


### PR DESCRIPTION
Hello, 

I like your plugin, but I'm missing a way to define nested keys that I would like to be excluded from deep.equal() comparison.

What do you think about the change? Could you approve it?