### PR TITLE
Override include on a par with equal

### DIFF
--- a/chai-exclude.js
+++ b/chai-exclude.js
@@ -209,10 +209,10 @@ function chaiExclude (chai, utils) {
   Assertion.overwriteMethod('equal', removeKeysAndAssert)
   Assertion.overwriteMethod('equals', removeKeysAndAssert)
 
-  Assertion.addChainableMethod('include', removeKeysAndAssert, keepChainingBehavior)
-  Assertion.addChainableMethod('contain', removeKeysAndAssert, keepChainingBehavior)
-  Assertion.addChainableMethod('contains', removeKeysAndAssert, keepChainingBehavior)
-  Assertion.addChainableMethod('includes', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.overwriteChainableMethod('include', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.overwriteChainableMethod('contain', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.overwriteChainableMethod('contains', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.overwriteChainableMethod('includes', removeKeysAndAssert, keepChainingBehavior)
 }
 
 module.exports = chaiExclude

--- a/chai-exclude.js
+++ b/chai-exclude.js
@@ -101,12 +101,12 @@ function chaiExclude (chai, utils) {
   }
 
   /**
-   * Override standard assertEqual method to remove the keys from other part of the equation.
+   * Override standard assertion logic method to remove the keys from other part of the equation.
    *
    * @param   {Object}    _super
    * @returns {Function}
    */
-  function assertEqual (_super) {
+  function removeKeysAndAssert (_super) {
     return function (val) {
       const props = utils.flag(this, 'excludingProps')
 
@@ -120,6 +120,18 @@ function chaiExclude (chai, utils) {
       arguments[0] = val
 
       return _super.apply(this, arguments)
+    }
+  }
+
+  /**
+   * Keep standard chaining logic.
+   *
+   * @param   {Object}    _super
+   * @returns {Function}
+   */
+  function keepChainingBehavior (_super) {
+    return function () {
+      _super.apply(this, arguments)
     }
   }
 
@@ -191,11 +203,16 @@ function chaiExclude (chai, utils) {
     utils.flag(this, 'excludingProps', props)
   })
 
-  Assertion.overwriteMethod('eq', assertEqual)
-  Assertion.overwriteMethod('eql', assertEqual)
-  Assertion.overwriteMethod('eqls', assertEqual)
-  Assertion.overwriteMethod('equal', assertEqual)
-  Assertion.overwriteMethod('equals', assertEqual)
+  Assertion.overwriteMethod('eq', removeKeysAndAssert)
+  Assertion.overwriteMethod('eql', removeKeysAndAssert)
+  Assertion.overwriteMethod('eqls', removeKeysAndAssert)
+  Assertion.overwriteMethod('equal', removeKeysAndAssert)
+  Assertion.overwriteMethod('equals', removeKeysAndAssert)
+
+  Assertion.addChainableMethod('include', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.addChainableMethod('contain', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.addChainableMethod('contains', removeKeysAndAssert, keepChainingBehavior)
+  Assertion.addChainableMethod('includes', removeKeysAndAssert, keepChainingBehavior)
 }
 
 module.exports = chaiExclude

--- a/chai-exclude.test.js
+++ b/chai-exclude.test.js
@@ -236,6 +236,11 @@ describe('chai-exclude', () => {
 
     it('should also exclude a key from the other object', () => {
       expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.equal({ a: 'z', b: 'b', c: 'c' })
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.include({ a: 'z', b: 'b', c: 'c' })
+    })
+
+    it('should also exclude a key from the other object and contain alias is used', () => {
+      expect({ a: 'a', b: 'b', c: 'c' }).excluding('a').to.deep.contain({ a: 'z', b: 'b', c: 'c' })
     })
 
     it('should exclude an array of keys from the object', () => {
@@ -327,6 +332,7 @@ describe('chai-exclude', () => {
       expectedObj.e = expectedObj
 
       expect(initialObj).excluding('a').to.deep.equal(expectedObj)
+      expect(initialObj).excluding('a').to.deep.include(expectedObj)
     })
   })
 
@@ -368,6 +374,7 @@ describe('chai-exclude', () => {
       }
 
       expect(initialObj).excludingEvery('a').to.deep.equal(expectedObj)
+      expect(initialObj).excludingEvery('a').to.deep.include(expectedObj)
     })
 
     it('should exclude a key from multiple levels of a given object when value is not an object', () => {


### PR DESCRIPTION
Hello,

Could you please take a look at these few changes that would allow to use the plugin for partial equality assertions?
I've added a couple of test cases to make sure overriding works correctly, so let me know please if you find this useful and I should add more.

Thanks!