### PR TITLE
Update for Chai 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@ yarn add chai-exclude --dev
 
 ## Usage
 
-### Require
-
-```js
-const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-
-chai.use(chaiExclude);
-```
-
 ### ES6 Import
 
 ```js

--- a/chai-exclude.js
+++ b/chai-exclude.js
@@ -1,4 +1,4 @@
-const fclone = require('fclone')
+import fclone from 'fclone'
 
 function chaiExclude (chai, utils) {
   const assert = chai.assert
@@ -215,5 +215,5 @@ function chaiExclude (chai, utils) {
   Assertion.overwriteChainableMethod('includes', removeKeysAndAssert, keepChainingBehavior)
 }
 
-module.exports = chaiExclude
-module.exports.default = chaiExclude // for Typescript
+const _default = chaiExclude // for Typescript
+export default _default

--- a/chai-exclude.test.js
+++ b/chai-exclude.test.js
@@ -1,8 +1,6 @@
 /* eslint-env mocha */
-
-const { use, assert, expect } = require('chai')
-
-const chaiExclude = require('./chai-exclude')
+import { use, assert, expect } from 'chai'
+import chaiExclude from './chai-exclude.js'
 
 use(chaiExclude)
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
-    "chai": "^4.3.7",
+    "chai": "^5.0.0",
     "mocha": "^10.2.0",
     "standard": "^17.0.0",
     "tsd": "^0.25.0"
@@ -42,6 +42,6 @@
     "fclone": "^1.0.11"
   },
   "peerDependencies": {
-    "chai": ">= 4.0.0 < 5"
+    "chai": ">= 5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Saugat Acharya <mesaugat@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/mesaugat/chai-exclude",
+  "type": "module",
   "files": [
     "chai-exclude.js",
     "index.d.ts"


### PR DESCRIPTION
Closes https://github.com/mesaugat/chai-exclude/issues/48

- The only breaking change was `require` is no longer supported.

All tests passed :
![image](https://github.com/mesaugat/chai-exclude/assets/7642809/d528605f-afe5-4717-b4af-334d0a56a919)
