### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mesaugat/chai-exclude/security/code-scanning/1](https://github.com/mesaugat/chai-exclude/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only requires read access to repository contents, the permissions should be set to `contents: read`. This limits the `GITHUB_TOKEN` to the minimum privileges necessary for the workflow to function correctly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity and clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
